### PR TITLE
feat: add host verification wizard

### DIFF
--- a/client/src/components/host-verification/host-verification-wizard.tsx
+++ b/client/src/components/host-verification/host-verification-wizard.tsx
@@ -1,0 +1,27 @@
+import { useEffect, useState } from "react";
+import { Step1Basics } from "./step1-basics";
+import { Step2Document } from "./step2-document";
+import { Step3Stripe } from "./step3-stripe";
+
+export function HostVerificationWizard() {
+  const [step, setStep] = useState(() => {
+    const stored = sessionStorage.getItem('host-verification-step');
+    return stored ? parseInt(stored, 10) : 1;
+    // step 1 default
+  });
+
+  useEffect(() => {
+    sessionStorage.setItem('host-verification-step', step.toString());
+  }, [step]);
+
+  const nextStep = () => setStep((prev) => Math.min(prev + 1, 3));
+
+  if (step === 1) {
+    return <Step1Basics onNext={nextStep} />;
+  }
+  if (step === 2) {
+    return <Step2Document onNext={nextStep} />;
+  }
+  return <Step3Stripe />;
+}
+

--- a/client/src/components/host-verification/step1-basics.tsx
+++ b/client/src/components/host-verification/step1-basics.tsx
@@ -1,0 +1,60 @@
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { useMutation } from "@tanstack/react-query";
+import { apiRequest } from "@/lib/queryClient";
+import { useToast } from "@/hooks/use-toast";
+import { Loader2 } from "lucide-react";
+
+interface Step1BasicsProps {
+  onNext: () => void;
+}
+
+export function Step1Basics({ onNext }: Step1BasicsProps) {
+  const { toast } = useToast();
+  const requestVerification = useMutation({
+    mutationFn: () => apiRequest("/api/host/request-verification", { method: "POST" }),
+    onSuccess: () => {
+      toast({
+        title: "Verificación iniciada",
+        description: "Revisa tu correo para activar tu cuenta de host",
+      });
+      onNext();
+    },
+    onError: () => {
+      toast({
+        title: "Error",
+        description: "No se pudo iniciar la verificación",
+        variant: "destructive",
+      });
+    },
+  });
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Verificación de Host</CardTitle>
+        <CardDescription>
+          Conviértete en un host verificado para ofrecer tus servicios profesionales
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-muted-foreground">
+          Para comenzar el proceso de verificación inicia la solicitud y revisa tu correo de activación.
+        </p>
+      </CardContent>
+      <CardFooter>
+        <Button onClick={() => requestVerification.mutate()} disabled={requestVerification.isPending}>
+          {requestVerification.isPending ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Iniciando...
+            </>
+          ) : (
+            "Iniciar Verificación"
+          )}
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}
+

--- a/client/src/components/host-verification/step2-document.tsx
+++ b/client/src/components/host-verification/step2-document.tsx
@@ -1,0 +1,156 @@
+import { useState } from "react";
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { useToast } from "@/hooks/use-toast";
+import { useMutation } from "@tanstack/react-query";
+import { Upload, FileCheck, Loader2 } from "lucide-react";
+
+const DOCUMENT_TYPES = [
+  { value: 'passport', label: 'Pasaporte' },
+  { value: 'national_id', label: 'DNI / Cédula Nacional' },
+  { value: 'drivers_license', label: 'Licencia de Conducir' },
+  { value: 'academic_title', label: 'Título Académico' },
+  { value: 'professional_certificate', label: 'Certificado Profesional' },
+  { value: 'business_card', label: 'Tarjeta de Presentación' },
+  { value: 'work_certificate', label: 'Certificado Laboral' },
+  { value: 'other', label: 'Otro (especificar)' },
+];
+
+const MAX_FILE_SIZE = 15 * 1024 * 1024; // 15MB
+
+interface Step2DocumentProps {
+  onNext: () => void;
+}
+
+export function Step2Document({ onNext }: Step2DocumentProps) {
+  const { toast } = useToast();
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [documentType, setDocumentType] = useState('');
+  const [customDocumentType, setCustomDocumentType] = useState('');
+
+  const uploadDocument = useMutation({
+    mutationFn: async () => {
+      if (!selectedFile || !documentType) return;
+      const formData = new FormData();
+      formData.append('document', selectedFile);
+      formData.append('documentType', documentType);
+      if (documentType === 'other' && customDocumentType) {
+        formData.append('documentTypeLabel', customDocumentType);
+      }
+
+      const response = await fetch('/api/host/upload-document', {
+        method: 'POST',
+        body: formData,
+        credentials: 'include',
+      });
+
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.message || 'Error al subir documento');
+      }
+
+      return response.json();
+    },
+    onSuccess: () => {
+      toast({ title: 'Documento subido', description: 'El documento se ha subido exitosamente' });
+      onNext();
+    },
+    onError: (error: Error) => {
+      toast({ title: 'Error', description: error.message, variant: 'destructive' });
+    },
+  });
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    if (file.size > MAX_FILE_SIZE) {
+      toast({
+        title: 'Archivo muy grande',
+        description: 'El archivo debe ser menor a 15MB',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    const allowedTypes = ['application/pdf', 'image/jpeg', 'image/jpg', 'image/png', 'image/webp'];
+    if (!allowedTypes.includes(file.type)) {
+      toast({
+        title: 'Tipo de archivo no permitido',
+        description: 'Solo se permiten archivos PDF, JPG, PNG o WEBP',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    setSelectedFile(file);
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Verificación de Documentos</CardTitle>
+        <CardDescription>Sube un documento para verificar tu identidad</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="document-type">Tipo de Documento</Label>
+          <Select value={documentType} onValueChange={setDocumentType}>
+            <SelectTrigger id="document-type">
+              <SelectValue placeholder="Selecciona el tipo de documento" />
+            </SelectTrigger>
+            <SelectContent>
+              {DOCUMENT_TYPES.map(type => (
+                <SelectItem key={type.value} value={type.value}>
+                  {type.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {documentType === 'other' && (
+          <div className="space-y-2">
+            <Label htmlFor="custom-type">Especifica el tipo de documento</Label>
+            <Input id="custom-type" value={customDocumentType} onChange={e => setCustomDocumentType(e.target.value)} />
+          </div>
+        )}
+
+        <div className="space-y-2">
+          <Label htmlFor="file-upload">Archivo (PDF, JPG, PNG o WEBP - máx 15MB)</Label>
+          <Input id="file-upload" type="file" accept=".pdf,.jpg,.jpeg,.png,.webp" onChange={handleFileSelect} />
+        </div>
+
+        {selectedFile && (
+          <Alert>
+            <FileCheck className="h-4 w-4" />
+            <AlertDescription>Archivo seleccionado: {selectedFile.name}</AlertDescription>
+          </Alert>
+        )}
+      </CardContent>
+      <CardFooter>
+        <Button
+          onClick={() => uploadDocument.mutate()}
+          disabled={!selectedFile || !documentType || (documentType === 'other' && !customDocumentType) || uploadDocument.isPending}
+        >
+          {uploadDocument.isPending ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Subiendo...
+            </>
+          ) : (
+            <>
+              <Upload className="mr-2 h-4 w-4" />
+              Subir Documento
+            </>
+          )}
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}
+

--- a/client/src/components/host-verification/step3-stripe.tsx
+++ b/client/src/components/host-verification/step3-stripe.tsx
@@ -1,0 +1,57 @@
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { useMutation } from "@tanstack/react-query";
+import { apiRequest } from "@/lib/queryClient";
+import { useToast } from "@/hooks/use-toast";
+import { Loader2, CreditCard } from "lucide-react";
+
+interface Step3StripeProps {
+  onNext?: () => void;
+}
+
+export function Step3Stripe({ onNext }: Step3StripeProps) {
+  const { toast } = useToast();
+  const getOnboardingLink = useMutation({
+    mutationFn: async () => {
+      const response = await apiRequest("/api/stripe/connect/onboarding-link", { method: "POST" });
+      return response.json();
+    },
+    onSuccess: (data) => {
+      window.location.href = data.url;
+      onNext && onNext();
+    },
+    onError: (error: Error) => {
+      toast({ title: "Error", description: error.message, variant: "destructive" });
+    },
+  });
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Configura Stripe Connect</CardTitle>
+        <CardDescription>Completa tu configuración de pagos en Stripe</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-muted-foreground">
+          Te redirigiremos a Stripe para que completes la verificación de tu cuenta y puedas recibir pagos.
+        </p>
+      </CardContent>
+      <CardFooter>
+        <Button onClick={() => getOnboardingLink.mutate()} disabled={getOnboardingLink.isPending}>
+          {getOnboardingLink.isPending ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Redirigiendo...
+            </>
+          ) : (
+            <>
+              <CreditCard className="mr-2 h-4 w-4" />
+              Continuar con Stripe
+            </>
+          )}
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}
+

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -46,7 +46,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiRequest } from "@/lib/queryClient";
 import { StripeConnectOnboarding } from "@/components/stripe-connect-onboarding";
 import { SessionRatingModal } from "@/components/session-rating-modal";
-import { HostVerificationForm } from "@/components/host-verification-form";
+import { HostVerificationWizard } from "@/components/host-verification/host-verification-wizard";
 import { UpcomingCallsBanner } from "@/components/upcoming-calls-banner";
 
 // Profile Management Component
@@ -735,7 +735,7 @@ export default function Dashboard() {
 
               {/* Host Verification Tab */}
               <TabsContent value="verification" className="mt-6">
-                <HostVerificationForm userId={user?.id} userStatus={user?.hostVerificationStatus} />
+                <HostVerificationWizard />
               </TabsContent>
             </Tabs>
           </CardContent>


### PR DESCRIPTION
## Summary
- add wizard-based host verification flow with steps for basics, document upload, and Stripe onboarding
- persist wizard progress using sessionStorage and integrate with dashboard

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: TS errors in server/storage and server/video-compression)*

------
https://chatgpt.com/codex/tasks/task_e_6896415624c88324a49fb5a4735a6ab7