### PR TITLE
fix: prevent pre-initialization access to user on profile

### DIFF
--- a/client/src/pages/user-profile.tsx
+++ b/client/src/pages/user-profile.tsx
@@ -51,21 +51,21 @@ export default function UserProfile() {
   // Reviews modal state
   const [showReviewsModal, setShowReviewsModal] = useState(false);
 
-  // Intelligent translation for description
-  const { 
-    translatedDescription, 
-    isTranslating, 
-    wasTranslated 
-  } = useIntelligentTranslation({
-    description: user?.description || '',
-    hostId: userId || '',
-    enabled: !!user?.description && !!userId
-  });
-
   // Fetch user profile
   const { data: user, isLoading: userLoading, error: userError } = useQuery<User>({
     queryKey: [`/api/users/${userId}`],
     enabled: !!userId,
+  });
+
+  // Intelligent translation for description
+  const {
+    translatedDescription,
+    isTranslating,
+    wasTranslated
+  } = useIntelligentTranslation({
+    description: user?.description || '',
+    hostId: userId || '',
+    enabled: !!user?.description && !!userId
   });
 
   // Scroll to top when component mounts or userId changes


### PR DESCRIPTION
## Summary
- fetch user profile before invoking intelligent translation hook to avoid accessing `user` before initialization

## Testing
- `npm test` (fails: server/__tests__/statusTransitions.test.ts > Host verification status transitions > rejects host verification)
- `npm run check` (fails: TypeScript errors in server/storage.ts and server/video-compression.ts)


------
https://chatgpt.com/codex/tasks/task_e_68964772553883248b402c0a96e65b9a