### PR TITLE
fix: build social links from url or username

### DIFF
--- a/client/src/pages/user-profile.tsx
+++ b/client/src/pages/user-profile.tsx
@@ -461,7 +461,7 @@ export default function UserProfile() {
                 {socialProfiles && Array.isArray(socialProfiles) && socialProfiles.length > 0 && (
                   <div className="flex gap-3">
                     {socialProfiles.map((profile: any) => {
-                      if (!profile?.platform?.baseUrl || !profile?.username) {
+                      if (!profile?.username) {
                         return null;
                       }
 
@@ -479,9 +479,10 @@ export default function UserProfile() {
                         }
                       };
 
-                      const platformUrl = profile.username.startsWith('http') 
-                        ? profile.username 
-                        : profile.platform.baseUrl + profile.username;
+                      const platformUrl = profile.url
+                        || (profile.username.startsWith('http')
+                          ? profile.username
+                          : (profile.platform?.baseUrl || '') + profile.username);
 
                       return (
                         <a


### PR DESCRIPTION
## Summary
- drop base URL requirement for user social profile links
- generate social profile URLs from explicit URL, full username, or platform base URL

## Testing
- `npm test` (fails: server/__tests__/statusTransitions.test.ts > Host verification status transitions > rejects host verification)


------
https://chatgpt.com/codex/tasks/task_e_68964e8a0b608324bbf2559b7c524e3c