### PR TITLE
refactor: require Resend configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ The project uses a monorepo architecture with clear separation of concerns:
 - Stripe account for payments
 - Agora.io account for video calls
 - OpenAI API key for AI features
-- Resend account for emails
+- Resend account for emails (domain verification required)
 
 ### Environment Variables
 Create a `.env` file with the following variables:
@@ -290,6 +290,8 @@ RESEND_FROM_EMAIL=noreply@dialoom.com
 PUBLIC_OBJECT_SEARCH_PATHS=/bucket/public
 PRIVATE_OBJECT_DIR=/bucket/private
 ```
+
+Before using the email service, verify your domain in the Resend dashboard.
 
 ### Installation Steps
 

--- a/server/email-service.ts
+++ b/server/email-service.ts
@@ -1,14 +1,22 @@
 import { Resend } from 'resend';
 import { storage } from './storage';
-import { 
-  EmailTemplate, 
-  EmailNotification, 
+import {
+  EmailTemplate,
+  EmailNotification,
   InsertEmailNotification,
   emailTemplateTypeEnum
 } from '@shared/schema';
 
-// Use the Resend API key provided by the user
-const RESEND_API_KEY = process.env.RESEND_API_KEY || 're_J1kjyvgF_EvCgVLwrMXx364p3m2ryg6QX';
+const RESEND_API_KEY = process.env.RESEND_API_KEY;
+const RESEND_FROM_EMAIL = process.env.RESEND_FROM_EMAIL;
+
+if (!RESEND_API_KEY) {
+  throw new Error('RESEND_API_KEY environment variable is required');
+}
+
+if (!RESEND_FROM_EMAIL) {
+  throw new Error('RESEND_FROM_EMAIL environment variable is required');
+}
 
 const resend = new Resend(RESEND_API_KEY);
 
@@ -91,7 +99,7 @@ class EmailService {
 
       // Send email via Resend
       const emailResult = await resend.emails.send({
-        from: 'Dialoom <api@dialoom.com>',
+        from: RESEND_FROM_EMAIL,
         to: params.recipientEmail,
         subject,
         html: htmlContent,


### PR DESCRIPTION
## Summary
- enforce presence of `RESEND_API_KEY` and `RESEND_FROM_EMAIL`
- send emails using configurable `RESEND_FROM_EMAIL`
- note Resend domain verification requirement in README

## Testing
- `npm test -- --run` *(fails: Host verification status transitions > rejects host verification)*

------
https://chatgpt.com/codex/tasks/task_e_6896588def98832490075fd0b3ba1d46