### PR TITLE
feat: redirect unauthenticated booking

### DIFF
--- a/client/src/components/booking-flow-direct.tsx
+++ b/client/src/components/booking-flow-direct.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useLocation } from "wouter";
 import { useTranslation } from "react-i18next";
 import { useToast } from "@/hooks/use-toast";
+import { useAuth } from "@/hooks/useAuth";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Calendar } from "@/components/ui/calendar";
@@ -70,6 +71,7 @@ export function BookingFlowDirect({
   const { t } = useTranslation();
   const { toast } = useToast();
   const [, setLocation] = useLocation();
+  const { isAuthenticated } = useAuth();
   
   const [selectedDate, setSelectedDate] = useState<Date | undefined>();
   const [selectedTime, setSelectedTime] = useState<string>("");
@@ -95,11 +97,7 @@ export function BookingFlowDirect({
       const response = await apiRequest('POST', '/api/booking-session', bookingData);
       return response.json();
     },
-    onSuccess: (data) => {
-      // Redirect to checkout with session ID
-      setLocation(`/checkout/${data.sessionId}`);
-    },
-    onError: (error: any) => {
+    onError: () => {
       toast({
         title: "Error",
         description: "Error al crear la sesión de reserva. Inténtalo de nuevo.",
@@ -127,7 +125,16 @@ export function BookingFlowDirect({
       selectedServices,
     };
 
-    createBookingSessionMutation.mutate(bookingData);
+    createBookingSessionMutation.mutate(bookingData, {
+      onSuccess: (data) => {
+        const checkoutUrl = `/checkout/${data.sessionId}`;
+        if (isAuthenticated) {
+          setLocation(checkoutUrl);
+        } else {
+          setLocation(`/login?redirect=${encodeURIComponent(checkoutUrl)}`);
+        }
+      },
+    });
   };
 
   return (


### PR DESCRIPTION
## Summary
- redirect guests from booking flow to login and preserve target checkout URL
- honor `redirect` parameter after sign in or sign up

## Testing
- `npm test` *(fails: server/__tests__/statusTransitions.test.ts > Host verification status transitions > rejects host verification)*

------
https://chatgpt.com/codex/tasks/task_e_68964eb4427c8324a330875009b3b814