### PR TITLE
Default verification badge disabled by default

### DIFF
--- a/scripts/init-admin-config.sql
+++ b/scripts/init-admin-config.sql
@@ -1,14 +1,15 @@
 -- Initialize admin configuration with default values
 -- This script sets up the default pricing and commission structure for Dialoom
 
-INSERT INTO admin_config (key, value, description, updated_by, created_at, updated_at) 
-VALUES 
+INSERT INTO admin_config (key, value, description, updated_by, created_at, updated_at)
+VALUES
   ('commission_rate', '0.10', 'Porcentaje de comisión que cobra Dialoom por cada transacción', 'system', NOW(), NOW()),
   ('vat_rate', '0.21', 'Porcentaje de IVA aplicado sobre la comisión', 'system', NOW(), NOW()),
   ('screen_sharing_price', '5.00', 'Precio adicional por servicio de compartir pantalla', 'system', NOW(), NOW()),
   ('translation_price', '10.00', 'Precio adicional por servicio de traducción simultánea', 'system', NOW(), NOW()),
   ('recording_price', '8.00', 'Precio adicional por grabación de videollamada', 'system', NOW(), NOW()),
-  ('transcription_price', '12.00', 'Precio adicional por transcripción automática', 'system', NOW(), NOW())
+  ('transcription_price', '12.00', 'Precio adicional por transcripción automática', 'system', NOW(), NOW()),
+  ('show_verified_badge', 'false', 'Muestra la insignia de verificación en los perfiles', 'system', NOW(), NOW())
 ON CONFLICT (key) DO NOTHING;
 
 -- Verify the configuration was inserted

--- a/server/__tests__/statusTransitions.test.ts
+++ b/server/__tests__/statusTransitions.test.ts
@@ -27,7 +27,7 @@ describe('Host verification status transitions', () => {
   it('rejects host verification', async () => {
     mockSet.mockClear();
     await storage.rejectHostVerification('user2', 'admin1', 'bad docs');
-    expect(mockSet).toHaveBeenCalledWith(expect.objectContaining({ hostVerificationStatus: 'rejected' }));
+    expect(mockSet).toHaveBeenCalledWith(expect.objectContaining({ hostVerificationStatus: 'REJECTED' }));
     expect(mockSet).toHaveBeenCalledWith(expect.objectContaining({ verificationStatus: 'rejected' }));
   });
 });

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -2035,10 +2035,10 @@ export class DatabaseStorage implements IStorage {
       this.getAdminConfig('show_verified_badge'),
       this.getAdminConfig('show_recommended_badge')
     ]);
-    
+
     return {
-      showVerified: verifiedConfig ? JSON.parse(verifiedConfig.value) : true,
-      showRecommended: recommendedConfig ? JSON.parse(recommendedConfig.value) : true
+      showVerified: verifiedConfig ? JSON.parse(verifiedConfig.value) : false,
+      showRecommended: recommendedConfig ? JSON.parse(recommendedConfig.value) : false
     };
   }
 


### PR DESCRIPTION
## Summary
- default `showVerified` and `showRecommended` settings to false when no admin config is present
- seed `show_verified_badge` admin config entry with a default of `false`
- align host verification rejection test with uppercase status

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68964ea0b344832485360ae0e74d0fd8