### PR TITLE
Add language selection translations

### DIFF
--- a/client/src/components/language-selector.tsx
+++ b/client/src/components/language-selector.tsx
@@ -8,9 +8,7 @@ import {
 import { useTranslation } from "react-i18next";
 
 export function LanguageSelector() {
-  const { i18n } = useTranslation();
-
-  const { t } = useTranslation();
+  const { i18n, t } = useTranslation();
   
   const languages = [
     { code: 'es', label: t('language.spanish'), short: 'ESP' },
@@ -27,10 +25,12 @@ export function LanguageSelector() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button 
-          variant="ghost" 
+        <Button
+          variant="ghost"
           size="sm"
           className="font-medium text-gray-600 hover:text-primary px-2 sm:px-3"
+          aria-label={t('language.label')}
+          title={t('language.select')}
         >
           {currentLang.short}
         </Button>

--- a/client/src/components/profile-edit-modal.tsx
+++ b/client/src/components/profile-edit-modal.tsx
@@ -14,6 +14,7 @@ import { isUnauthorizedError } from "@/lib/authUtils";
 import { supabase } from "@/lib/supabase";
 import { Camera, User as UserIcon, Upload } from "lucide-react";
 import type { User, Country, Language, Skill, Category } from "@shared/schema";
+import { useTranslation } from "react-i18next";
 
 interface ProfileEditModalProps {
   isOpen: boolean;
@@ -24,6 +25,7 @@ interface ProfileEditModalProps {
 export function ProfileEditModal({ isOpen, onClose, user }: ProfileEditModalProps) {
   const { toast } = useToast();
   const queryClient = useQueryClient();
+  const { t } = useTranslation();
   
   const [formData, setFormData] = useState({
     firstName: user.firstName || "",
@@ -429,20 +431,20 @@ export function ProfileEditModal({ isOpen, onClose, user }: ProfileEditModalProp
             </div>
 
             <div>
-              <Label className="text-sm font-medium text-gray-700">
-                Idioma Principal
-              </Label>
-              <Select 
-                value={formData.primaryLanguageId?.toString() || ""} 
-                onValueChange={(value) => setFormData(prev => ({ ...prev, primaryLanguageId: value ? parseInt(value) : null }))}
-              >
-                <SelectTrigger className="mt-1">
-                  <SelectValue placeholder="Selecciona tu idioma principal" />
-                </SelectTrigger>
-                <SelectContent>
-                  {languages.map((language) => (
-                    <SelectItem key={language.id} value={language.id.toString()}>
-                      {language.name}
+                <Label className="text-sm font-medium text-gray-700">
+                  {t('language.label')}
+                </Label>
+                <Select
+                  value={formData.primaryLanguageId?.toString() || ""}
+                  onValueChange={(value) => setFormData(prev => ({ ...prev, primaryLanguageId: value ? parseInt(value) : null }))}
+                >
+                  <SelectTrigger className="mt-1">
+                    <SelectValue placeholder={t('language.select')} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {languages.map((language) => (
+                      <SelectItem key={language.id} value={language.id.toString()}>
+                        {language.name}
                     </SelectItem>
                   ))}
                 </SelectContent>
@@ -451,9 +453,9 @@ export function ProfileEditModal({ isOpen, onClose, user }: ProfileEditModalProp
 
             {/* Secondary Languages */}
             <div className="md:col-span-2">
-              <Label className="text-sm font-medium text-gray-700 mb-2 block">
-                Idiomas Secundarios
-              </Label>
+                <Label className="text-sm font-medium text-gray-700 mb-2 block">
+                  {t('userProfile.languages')}
+                </Label>
               <div className="grid grid-cols-2 md:grid-cols-3 gap-2 max-h-32 overflow-y-auto border rounded-md p-2">
                 {languages
                   .filter(lang => lang.id !== formData.primaryLanguageId)

--- a/client/src/i18n/locales/ca.json
+++ b/client/src/i18n/locales/ca.json
@@ -371,8 +371,10 @@
     "gdprCompliance": "Complim amb RGPD"
   },
   "language": {
+    "label": "Idioma",
+    "select": "Selecciona idioma",
     "spanish": "Español",
-    "english": "English", 
+    "english": "English",
     "catalan": "Català"
   },
   "adminTabs": {

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -363,8 +363,10 @@
     "gdprCompliance": "GDPR Compliant"
   },
   "language": {
+    "label": "Language",
+    "select": "Select language",
     "spanish": "Español",
-    "english": "English", 
+    "english": "English",
     "catalan": "Català"
   },
   "adminTabs": {

--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -372,8 +372,10 @@
     "gdprCompliance": "Cumplimos con RGPD"
   },
   "language": {
+    "label": "Idioma",
+    "select": "Selecciona idioma",
     "spanish": "Español",
-    "english": "English", 
+    "english": "English",
     "catalan": "Català"
   },
   "adminTabs": {


### PR DESCRIPTION
## Summary
- add generic language and selection strings to locale files
- use new language keys in LanguageSelector and profile edit modal

## Testing
- `npm test` (fails: Host verification status transitions rejects host verification)
- `npm run check` (fails: various TypeScript errors)


------
https://chatgpt.com/codex/tasks/task_e_68964e9994088324943464377d9cfd43