### PR TITLE
feat: add host language selection in booking flow

### DIFF
--- a/client/src/components/payment-checkout.tsx
+++ b/client/src/components/payment-checkout.tsx
@@ -25,6 +25,7 @@ interface CheckoutFormProps {
       recording: boolean;
       transcription: boolean;
     };
+    language?: string;
   };
   onSuccess: () => void;
   onCancel: () => void;
@@ -67,6 +68,7 @@ const CheckoutForm = ({ bookingDetails, onSuccess, onCancel }: CheckoutFormProps
         bookingId: bookingDetails.id,
         amount: calculateTotal(),
         serviceAddons: bookingDetails.serviceAddons,
+        language: bookingDetails.language,
       });
       const data = await response.json();
       const { clientSecret } = data;


### PR DESCRIPTION
## Summary
- allow users to select session language in booking flows
- load host languages from API and forward choice to booking/payment requests

## Testing
- `npm test` *(fails: AssertionError in statusTransitions.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68964e97671483249e9ade609f0a00e2