### PR TITLE
feat: show call language in sessions

### DIFF
--- a/client/src/components/upcoming-calls-banner.tsx
+++ b/client/src/components/upcoming-calls-banner.tsx
@@ -2,13 +2,17 @@ import { useState, useEffect } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Calendar, Clock, Video, User, Timer, AlertCircle } from "lucide-react";
+import { Calendar, Clock, Video, User, Timer, AlertCircle, Languages } from "lucide-react";
 import { format, differenceInMilliseconds, differenceInMinutes, differenceInHours, differenceInDays } from "date-fns";
 import { es } from "date-fns/locale";
 import type { Booking } from "@shared/schema";
 
+interface BookingWithLanguage extends Booking {
+  callLanguage?: string;
+}
+
 interface UpcomingCallsBannerProps {
-  bookings: Booking[];
+  bookings: BookingWithLanguage[];
   userId?: string;
 }
 
@@ -134,11 +138,17 @@ export function UpcomingCallsBanner({ bookings, userId }: UpcomingCallsBannerPro
                     {nextBooking.startTime} - {nextBooking.duration} min
                   </span>
                 </div>
+                {nextBooking.callLanguage && (
+                  <div className="flex items-center gap-2">
+                    <Languages className="w-4 h-4 text-gray-500" />
+                    <span className="font-medium">{nextBooking.callLanguage}</span>
+                  </div>
+                )}
               </div>
               <div className="flex items-center gap-2">
                 <User className="w-4 h-4 text-gray-500" />
                 <span className="text-sm text-gray-600">
-                  {nextBooking.hostId === userId 
+                  {nextBooking.hostId === userId
                     ? `Invitado: Usuario #${nextBooking.guestId}`
                     : `Mentor: ${nextBooking.hostName}`
                   }

--- a/client/src/components/video-call-lobby.tsx
+++ b/client/src/components/video-call-lobby.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Mic, MicOff, Video, VideoOff, Settings, Loader2 } from "lucide-react";
+import { Mic, MicOff, Video, VideoOff, Settings, Loader2, Languages } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 
 interface VideoCallLobbyProps {
@@ -13,6 +13,7 @@ interface VideoCallLobbyProps {
     date: string;
     time: string;
     duration: number;
+    callLanguage?: string;
   };
 }
 
@@ -122,6 +123,12 @@ export function VideoCallLobby({ onJoinCall, onCancel, hostName, sessionDetails 
           <p className="text-sm text-gray-600">
             {sessionDetails.date} a las {sessionDetails.time} • {sessionDetails.duration} minutos
           </p>
+          {sessionDetails.callLanguage && (
+            <p className="text-sm text-gray-600 flex items-center gap-1 mt-1">
+              <Languages className="w-4 h-4" />
+              {sessionDetails.callLanguage}
+            </p>
+          )}
         </CardHeader>
         <CardContent>
           <div className="grid md:grid-cols-2 gap-6">

--- a/client/src/components/video-call.tsx
+++ b/client/src/components/video-call.tsx
@@ -21,7 +21,8 @@ import {
   PhoneOff,
   Monitor,
   MonitorOff,
-  Loader2
+  Loader2,
+  Languages
 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 
@@ -31,9 +32,10 @@ interface VideoCallProps {
   token: string;
   userId: string;
   onEndCall: () => void;
+  callLanguage?: string;
 }
 
-function VideoCallContent({ appId, channelName, token, userId, onEndCall }: VideoCallProps) {
+function VideoCallContent({ appId, channelName, token, userId, onEndCall, callLanguage }: VideoCallProps) {
   const { localCameraTrack } = useLocalCameraTrack();
   const { localMicrophoneTrack } = useLocalMicrophoneTrack();
   const remoteUsers = useRemoteUsers();
@@ -103,6 +105,12 @@ function VideoCallContent({ appId, channelName, token, userId, onEndCall }: Vide
 
   return (
     <div className="h-screen bg-gray-900 flex flex-col">
+      {callLanguage && (
+        <div className="bg-gray-800 text-gray-100 text-sm px-4 py-2 flex items-center gap-2 justify-center">
+          <Languages className="w-4 h-4" />
+          <span>{callLanguage}</span>
+        </div>
+      )}
       {/* Video Grid */}
       <div className="flex-1 p-4">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4 h-full">
@@ -181,19 +189,20 @@ function VideoCallContent({ appId, channelName, token, userId, onEndCall }: Vide
   );
 }
 
-export function VideoCall({ appId, channelName, token, userId, onEndCall }: VideoCallProps) {
+export function VideoCall({ appId, channelName, token, userId, onEndCall, callLanguage }: VideoCallProps) {
   const client = useRTCClient(
     AgoraRTC.createClient({ codec: "vp8", mode: "rtc" })
   );
 
   return (
     <AgoraRTCProvider client={client}>
-      <VideoCallContent 
+      <VideoCallContent
         appId={appId}
         channelName={channelName}
         token={token}
         userId={userId}
         onEndCall={onEndCall}
+        callLanguage={callLanguage}
       />
     </AgoraRTCProvider>
   );

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -35,13 +35,18 @@ import {
   Plus,
   CheckCircle2,
   CreditCard,
-  Shield
+  Shield,
+  Languages
 } from "lucide-react";
 import { format } from "date-fns";
 import { es } from "date-fns/locale";
 
 // Import additional types and utilities
 import type { Booking, Invoice, MediaContent, User, HostPricing } from "@shared/schema";
+
+interface BookingWithLanguage extends Booking {
+  callLanguage?: string;
+}
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiRequest } from "@/lib/queryClient";
 import { StripeConnectOnboarding } from "@/components/stripe-connect-onboarding";
@@ -337,7 +342,7 @@ export default function Dashboard() {
   const currentUser = user || (isAdmin ? { id: 'admin-view', name: 'Admin View', isAdmin: true } : null);
 
   // Fetch bookings - disabled for admin view
-  const { data: bookings = [], isLoading: bookingsLoading } = useQuery<Booking[]>({
+  const { data: bookings = [], isLoading: bookingsLoading } = useQuery<BookingWithLanguage[]>({
     queryKey: ["/api/bookings"],
     enabled: !!user && !isAdmin,
   });
@@ -622,6 +627,12 @@ export default function Dashboard() {
                             </span>
                             <Clock className="w-4 h-4 text-gray-500 ml-4" />
                             <span>{booking.startTime} - {booking.duration} min</span>
+                            {booking.callLanguage && (
+                              <>
+                                <Languages className="w-4 h-4 text-gray-500 ml-4" />
+                                <span>{booking.callLanguage}</span>
+                              </>
+                            )}
                           </div>
                           <p className="text-sm text-gray-600">Invitado: Usuario #{booking.guestId}</p>
                         </div>
@@ -660,7 +671,13 @@ export default function Dashboard() {
                               <span className="font-medium">
                                 {format(new Date(booking.scheduledDate), "d 'de' MMMM 'de' yyyy", { locale: es })}
                               </span>
-                              <Badge 
+                              {booking.callLanguage && (
+                                <>
+                                  <Languages className="w-4 h-4 text-gray-500 ml-4" />
+                                  <span>{booking.callLanguage}</span>
+                                </>
+                              )}
+                              <Badge
                                 variant={booking.status === "completed" ? "default" : "secondary"}
                                 className="ml-2"
                               >

--- a/client/src/pages/video-call-room.tsx
+++ b/client/src/pages/video-call-room.tsx
@@ -120,7 +120,8 @@ export default function VideoCallRoom() {
           sessionDetails={{
             date: new Date(callData.scheduledDate).toLocaleDateString('es-ES'),
             time: callData.startTime,
-            duration: callData.duration
+            duration: callData.duration,
+            callLanguage: callData.callLanguage
           }}
         />
         
@@ -148,6 +149,7 @@ export default function VideoCallRoom() {
         token={callData.token}
         userId={user && typeof user === 'object' && 'id' in user ? String(user.id) : ""}
         onEndCall={handleEndCall}
+        callLanguage={callData.callLanguage}
       />
       
       {/* Rating Modal */}


### PR DESCRIPTION
## Summary
- Display selected language in UpcomingCallsBanner using icon and label
- Surface call language in dashboard booking lists and propagate to banner
- Show agreed language in video call lobby and active session screens

## Testing
- `npm test` *(fails: server/__tests__/statusTransitions.test.ts)*


------
https://chatgpt.com/codex/tasks/task_e_68964e98e5c88324bb07430b68dd324e