### PR TITLE
Add icon URL support for social profiles

### DIFF
--- a/client/src/pages/user-profile.tsx
+++ b/client/src/pages/user-profile.tsx
@@ -465,8 +465,18 @@ export default function UserProfile() {
                         return null;
                       }
 
-                      const getIcon = (platformName: string) => {
-                        switch (platformName?.toLowerCase()) {
+                      const getIcon = (profile: any) => {
+                        if (profile?.platform?.iconUrl) {
+                          return (
+                            <img
+                              src={profile.platform.iconUrl}
+                              alt={profile.platform.name || ''}
+                              className="w-5 h-5"
+                            />
+                          );
+                        }
+
+                        switch (profile.platform?.name?.toLowerCase()) {
                           case 'instagram': return <SiInstagram className="w-5 h-5" />;
                           case 'twitter': return <SiX className="w-5 h-5" />;
                           case 'linkedin': return <SiLinkedin className="w-5 h-5" />;
@@ -492,7 +502,7 @@ export default function UserProfile() {
                           className="flex items-center justify-center w-10 h-10 rounded-full bg-[hsl(188,100%,38%)] text-white hover:bg-[hsl(188,100%,32%)] transition-colors"
                           title={`${profile.platform.name || 'Social'}: ${profile.username}`}
                         >
-                          {getIcon(profile.platform.name || '')}
+                          {getIcon(profile)}
                         </a>
                       );
                     }).filter(Boolean)}

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1591,6 +1591,7 @@ export class DatabaseStorage implements IStorage {
           id: socialPlatforms.id,
           name: socialPlatforms.name,
           baseUrl: socialPlatforms.baseUrl,
+          iconUrl: socialPlatforms.iconUrl,
         }
       })
       .from(userSocialProfiles)


### PR DESCRIPTION
## Summary
- include `iconUrl` when querying user social profiles
- render provided social platform icons on profile page before fallback icons

## Testing
- `npm test` (fails: AssertionError expected spy to be called with arguments)
- `npm run check` (fails: various TypeScript errors)


------
https://chatgpt.com/codex/tasks/task_e_68964e8cc0f483248389ca493dfb4ebf