### PR TITLE
Handle missing Resend configuration gracefully

### DIFF
--- a/ENVIRONMENT_VARIABLES.md
+++ b/ENVIRONMENT_VARIABLES.md
@@ -61,6 +61,8 @@ RESEND_API_KEY=re_[obtener de resend.com]
 RESEND_FROM_EMAIL=noreply@tudominio.com
 ```
 
+> Si no se configuran estas variables, el servicio de correo se desactivará, pero la aplicación continuará funcionando.
+
 **Pasos para obtener estos valores:**
 1. Crear cuenta en https://resend.com/
 2. Verificar tu dominio
@@ -100,6 +102,7 @@ AGORA_APP_CERTIFICATE=tu_app_certificate_aqui
 OPENAI_API_KEY=sk-...
 
 # Resend
+# (Opcional) Requerido solo si se desea habilitar el envío de correos
 RESEND_API_KEY=re_...
 RESEND_FROM_EMAIL=noreply@tudominio.com
 

--- a/server/email-service.ts
+++ b/server/email-service.ts
@@ -10,15 +10,8 @@ import {
 const RESEND_API_KEY = process.env.RESEND_API_KEY;
 const RESEND_FROM_EMAIL = process.env.RESEND_FROM_EMAIL;
 
-if (!RESEND_API_KEY) {
-  throw new Error('RESEND_API_KEY environment variable is required');
-}
-
-if (!RESEND_FROM_EMAIL) {
-  throw new Error('RESEND_FROM_EMAIL environment variable is required');
-}
-
-const resend = new Resend(RESEND_API_KEY);
+// Only initialize Resend when the required environment variables are present
+const resend = RESEND_API_KEY ? new Resend(RESEND_API_KEY) : null;
 
 export interface EmailVariables {
   [key: string]: string | number | boolean;
@@ -42,6 +35,10 @@ class EmailService {
    */
   async sendEmail(params: SendEmailParams): Promise<boolean> {
     try {
+      if (!resend || !RESEND_FROM_EMAIL) {
+        console.warn('Resend email service is not configured. Skipping email send.');
+        return false;
+      }
       let template: EmailTemplate | null = null;
       let subject: string;
       let htmlContent: string;


### PR DESCRIPTION
## Summary
- Avoid crashing when `RESEND_API_KEY` or `RESEND_FROM_EMAIL` are missing by only instantiating Resend when configured and skipping email sending otherwise
- Document that Resend variables are optional and only required to enable the email service

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896666bcb348324a6cc84821b9f0d7c