### PR TITLE
feat: add centralized error handling

### DIFF
--- a/server/error-handler.ts
+++ b/server/error-handler.ts
@@ -1,9 +1,0 @@
-import type { Request, Response, NextFunction } from "express";
-
-export function errorHandler(err: any, _req: Request, res: Response, _next: NextFunction) {
-  const status = err.status || err.statusCode || 500;
-  const message = err.message || "Internal Server Error";
-
-  res.status(status).json({ message });
-  throw err;
-}

--- a/server/index.ts
+++ b/server/index.ts
@@ -5,7 +5,7 @@ import cors from "cors";
 import compression from "compression";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
-import { errorHandler } from "./error-handler";
+import { errorHandler } from "./middleware/errorHandler";
 
 const CLIENT_ORIGIN = process.env.CLIENT_ORIGIN;
 

--- a/server/middleware/asyncHandler.ts
+++ b/server/middleware/asyncHandler.ts
@@ -1,0 +1,13 @@
+import type { RequestHandler } from "express";
+
+export function asyncHandler(fn: RequestHandler): RequestHandler {
+  return function wrapped(req, res, next) {
+    Promise.resolve(fn(req, res, next)).catch(next);
+  };
+}
+
+export function wrapHandlers(handlers: any[]) {
+  return handlers.map((h) =>
+    typeof h === "function" && h.length < 4 ? asyncHandler(h as RequestHandler) : h,
+  );
+}

--- a/server/middleware/errorHandler.ts
+++ b/server/middleware/errorHandler.ts
@@ -1,0 +1,18 @@
+import type { Request, Response, NextFunction } from "express";
+import debug from "debug";
+
+const log = debug("server:boot");
+
+export function errorHandler(
+  err: any,
+  _req: Request,
+  res: Response,
+  _next: NextFunction,
+) {
+  const status = err.status || err.statusCode || 500;
+  const message = err instanceof Error ? err.message : "Internal Server Error";
+  log(err);
+  res.status(status).json({ message });
+}
+
+export default errorHandler;


### PR DESCRIPTION
## Summary
- add middleware-based error handler with debug logging
- wrap async route handlers to forward errors

## Testing
- `npm test` *(fails: Handlebars is not defined)*
- `npm run check` *(fails: TS errors in client components)*

------
https://chatgpt.com/codex/tasks/task_e_689677beeb0483249a90be0c46128670