### PR TITLE
feat: configure client origin

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -6,13 +6,12 @@ import compression from "compression";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
 import { errorHandler } from "./middleware/errorHandler";
-
-const CLIENT_ORIGIN = process.env.CLIENT_ORIGIN;
+import { env } from "./utils/env";
 
 const app = express();
 
 app.use(helmet());
-app.use(cors({ origin: CLIENT_ORIGIN, credentials: true }));
+app.use(cors({ origin: env.CLIENT_ORIGIN, credentials: true }));
 app.use(compression());
 app.use(express.json({ limit: "2mb" }));
 app.use(express.urlencoded({ extended: false }));

--- a/server/utils/env.ts
+++ b/server/utils/env.ts
@@ -20,7 +20,7 @@ const envSchema = z.object({
   RESEND_FROM_EMAIL: z.string().optional(),
   SUPABASE_URL: z.string().optional(),
   SUPABASE_SERVICE_ROLE_KEY: z.string().optional(),
-  CLIENT_ORIGIN: z.string().optional(),
+  CLIENT_ORIGIN: z.string().default("http://localhost:5173"),
   REPLIT_DOMAINS: z.string().optional(),
   APP_URL: z.string().optional(),
   STRIPE_WEBHOOK_SECRET: z.string().optional(),


### PR DESCRIPTION
## Summary
- default CLIENT_ORIGIN env to http://localhost:5173
- use env.CLIENT_ORIGIN for CORS configuration

## Testing
- `npm test` *(fails: Handlebars is not defined)*
- `npm run check` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_689679fa69d8832499c7b5ce9444b121