### PR TITLE
refactor: relocate Vite config into client

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -18,14 +18,14 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      "@": path.resolve(import.meta.dirname, "client", "src"),
-      "@shared": path.resolve(import.meta.dirname, "shared"),
-      "@assets": path.resolve(import.meta.dirname, "attached_assets"),
+      "@": path.resolve(import.meta.dirname, "src"),
+      "@shared": path.resolve(import.meta.dirname, "..", "shared"),
+      "@assets": path.resolve(import.meta.dirname, "..", "attached_assets"),
     },
   },
-  root: path.resolve(import.meta.dirname, "client"),
+  root: path.resolve(import.meta.dirname),
   build: {
-    outDir: path.resolve(import.meta.dirname, "dist/public"),
+    outDir: path.resolve(import.meta.dirname, "..", "dist/public"),
     emptyOutDir: true,
   },
   server: {
@@ -33,5 +33,8 @@ export default defineConfig({
       strict: true,
       deny: ["**/.*"],
     },
+  },
+  define: {
+    "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV),
   },
 });

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -3,7 +3,7 @@ import fs from "fs";
 import path from "path";
 import { createServer as createViteServer, createLogger } from "vite";
 import { type Server } from "http";
-import viteConfig from "../vite.config";
+import viteConfig from "../client/vite.config";
 import { nanoid } from "nanoid";
 
 const viteLogger = createLogger();


### PR DESCRIPTION
## Summary
- move Vite configuration into the `client/` directory
- expose `process.env.NODE_ENV` to the client build via Vite `define`
- update server to import client Vite config

## Testing
- `npm test -- --run` *(fails: Handlebars is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6896c6879f6c8324bb0a6a1679fb5402