### PR TITLE
feat: move Vite config to client and expose env

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -18,14 +18,13 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      "@": path.resolve(import.meta.dirname, "client", "src"),
-      "@shared": path.resolve(import.meta.dirname, "shared"),
-      "@assets": path.resolve(import.meta.dirname, "attached_assets"),
+      "@": path.resolve(import.meta.dirname, "src"),
+      "@shared": path.resolve(import.meta.dirname, "..", "shared"),
+      "@assets": path.resolve(import.meta.dirname, "..", "attached_assets"),
     },
   },
-  root: path.resolve(import.meta.dirname, "client"),
   build: {
-    outDir: path.resolve(import.meta.dirname, "dist/public"),
+    outDir: path.resolve(import.meta.dirname, "..", "dist/public"),
     emptyOutDir: true,
   },
   server: {
@@ -34,4 +33,8 @@ export default defineConfig({
       deny: ["**/.*"],
     },
   },
+  define: {
+    "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV),
+  },
 });
+


### PR DESCRIPTION
## Summary
- move root `vite.config.ts` into `client/`
- expose `process.env.NODE_ENV` in Vite config
- update aliases and build paths for new config location

## Testing
- `npm test` *(fails: Handlebars is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6896c6d01ff48324a60c545473ae9ab9