### PR TITLE
Add booking session query in checkout

### DIFF
--- a/client/src/pages/checkout.tsx
+++ b/client/src/pages/checkout.tsx
@@ -117,6 +117,14 @@ export default function Checkout() {
   const { session, clearSession } = useBookingSessionStore();
 
   // Get booking session data
+  const { data: sessionData, isLoading } = useQuery({
+    queryKey: ["/api/booking-session", params?.sessionId],
+    queryFn: async () => {
+      const response = await apiRequest(
+        `/api/booking-session/${params?.sessionId}`
+      );
+      return response.json();
+    },
     enabled: !!params?.sessionId,
     retry: false,
   });


### PR DESCRIPTION
## Summary
- fetch booking session data on checkout using `useQuery`

## Testing
- `npm test` *(fails: Handlebars is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6896ce0aef5483249598219d5d3c6836