### PR TITLE
fix: close LoginPage JSX and component

### DIFF
--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -78,7 +78,7 @@ export default function LoginPage() {
     };
 
     handleOAuthCallback();
-
+  }, []);
 
   const handleSignIn = async (e: React.FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- close LoginPage useEffect hook properly
- ensure LoginPage ends with newline and component closure

## Testing
- `npm test -- --run` *(fails: Handlebars is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6896d15132988324850cff93de65830f