### PR TITLE
feat: add error boundary

### DIFF
--- a/client/src/components/ErrorBoundary.tsx
+++ b/client/src/components/ErrorBoundary.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    console.error("ErrorBoundary caught an error", error, errorInfo);
+  }
+
+  handleReload = () => {
+    window.location.reload();
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="min-h-screen flex flex-col items-center justify-center p-4 text-center">
+          <h1 className="text-2xl font-bold mb-4">Algo salió mal.</h1>
+          <button
+            onClick={this.handleReload}
+            className="px-4 py-2 bg-[hsl(188,100%,38%)] text-white rounded"
+          >
+            Reintentar
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;
+

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,5 +1,10 @@
 import { createRoot } from "react-dom/client";
 import App from "./App";
 import "./index.css";
+import ErrorBoundary from "./components/ErrorBoundary";
 
-createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById("root")!).render(
+  <ErrorBoundary>
+    <App />
+  </ErrorBoundary>
+);


### PR DESCRIPTION
## Summary
- add ErrorBoundary component to handle runtime errors and offer reload
- wrap App component with ErrorBoundary in main entry

## Testing
- `npm test` *(fails: Handlebars is not defined)*
- `npm run check` *(fails: TS errors in booking-flow-direct and profile-edit-modal)*

------
https://chatgpt.com/codex/tasks/task_e_6896f6fa0afc83248bece6a39a82e87a