### PR TITLE
chore: add server tsconfig for builds

### DIFF
--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "../dist/server",
+    "allowImportingTsExtensions": false
+  },
+  "include": ["./**/*"]
+}


### PR DESCRIPTION
## Summary
- add server-specific tsconfig to allow emitting compiled JS into `dist/server`

## Testing
- `npm run build:server` *(fails: Option 'allowImportingTsExtensions' can only be used when either 'noEmit' or 'emitDeclarationOnly' is set.)*
- `npm test` *(fails: connect ECONNREFUSED 127.0.0.1:1106)*

------
https://chatgpt.com/codex/tasks/task_e_68974a8fb85c8324b521456b9e042632