### PR TITLE
fix: coerce boolean fields in profile schema

### DIFF
--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -401,11 +401,11 @@ export const updateUserProfileSchema = createInsertSchema(users).omit({
   postalCode: z.string().nullable().optional(),
   phone: z.string().nullable().optional(),
   // Admin/Role fields for admin panel updates
-  isAdmin: z.boolean().optional(),
-  isHost: z.boolean().optional(),
+  isAdmin: z.coerce.boolean().optional(),
+  isHost: z.coerce.boolean().optional(),
   role: z.string().optional(),
-  isActive: z.boolean().optional(),
-  isVerified: z.boolean().optional(),
+  isActive: z.coerce.boolean().optional(),
+  isVerified: z.coerce.boolean().optional(),
   // Video call topics for hosts
   videoCallTopics: z.array(z.string()).optional(),
   // Purpose/goal of the host's services - for filtering


### PR DESCRIPTION
## Summary
- allow string boolean values for isAdmin and related flags in updateUserProfile schema

## Testing
- `npm test -- --run` *(fails: connect ECONNREFUSED 127.0.0.1:1106)*

------
https://chatgpt.com/codex/tasks/task_e_689773854d2c8324bb90ce2b6ff468d6